### PR TITLE
Get successful temperature readings from SHTc3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ util_chip_id/chip_id
 util_net_downlink/net_downlink
 util_boot/boot
 util_spectral_scan/spectral_scan
+*/.project
+
+remotebuild.sh

--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>sx1302_hal</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2.1.0
+2.1.0-NorwichHackspace

--- a/libloragw/Makefile
+++ b/libloragw/Makefile
@@ -123,6 +123,7 @@ libloragw.a: $(OBJDIR)/loragw_spi.o \
 			 $(OBJDIR)/loragw_debug.o \
 			 $(OBJDIR)/loragw_hal.o \
 			 $(OBJDIR)/loragw_lbt.o \
+			 $(OBJDIR)/loragw_sht.o \
 			 $(OBJDIR)/loragw_stts751.o \
 			 $(OBJDIR)/loragw_gps.o \
 			 $(OBJDIR)/loragw_sx1302_timestamp.o \

--- a/libloragw/inc/loragw_hal.h
+++ b/libloragw/inc/loragw_hal.h
@@ -23,6 +23,7 @@ License: Revised BSD License, see LICENSE.TXT file include in the project
 #include <stdbool.h>    /* bool type */
 
 #include "loragw_com.h"
+#include "loragw_i2c.h"
 
 #include "config.h"     /* library configuration options (dynamically generated) */
 
@@ -158,6 +159,7 @@ struct lgw_conf_board_s {
     bool            lorawan_public; /*!> Enable ONLY for *public* networks using the LoRa MAC protocol */
     uint8_t         clksrc;         /*!> Index of RF chain which provides clock to concentrator */
     bool            full_duplex;    /*!> Indicates if the gateway operates in full duplex mode or not */
+    lgw_temp_type_t  temp_type;     /*!> The external device type to use for temperature adjusted RSSI reading */
     lgw_com_type_t  com_type;       /*!> The COMmunication interface (SPI/USB) to connect to the SX1302 */
     char            com_path[64];   /*!> Path to access the COM device to connect to the SX1302 */
 };

--- a/libloragw/inc/loragw_hal.h
+++ b/libloragw/inc/loragw_hal.h
@@ -549,7 +549,7 @@ int lgw_get_eui(uint64_t * eui);
 @param temperature The temperature measured, in degree celcius
 @return LGW_HAL_ERROR id the operation failed, LGW_HAL_SUCCESS else
 */
-int lgw_get_temperature(float * temperature);
+int lgw_get_temperature(float * temperature, float * humidity);
 
 /**
 @brief Allow user to check the version/options of the library once compiled

--- a/libloragw/inc/loragw_i2c.h
+++ b/libloragw/inc/loragw_i2c.h
@@ -24,6 +24,16 @@ License: Revised BSD License, see LICENSE.TXT file include in the project
 #include "config.h"    /* library configuration options (dynamically generated) */
 
 /* -------------------------------------------------------------------------- */
+/* --- PUBLIC TYPES --------------------------------------------------------- */
+
+typedef enum temp_type_e {
+	LGW_TEMP_UNKNOWN,
+	LGW_TEMP_FAKE,
+    LGW_TEMP_SHT3x
+} lgw_temp_type_t;
+
+
+/* -------------------------------------------------------------------------- */
 /* --- PUBLIC CONSTANTS ----------------------------------------------------- */
 
 #define LGW_I2C_SUCCESS     0
@@ -79,6 +89,11 @@ int i2c_linuxdev_write(int i2c_fd, uint8_t device_addr, uint8_t reg_addr, uint8_
 @return 0 if I2C data write is successful, -1 else
 */
 int i2c_linuxdev_write_buffer(int i2c_fd, uint8_t device_addr, uint8_t *buffer, uint8_t size);
+
+/**
+ *
+ **/
+lgw_temp_type_t lgw_temp_type(void);
 
 #endif
 

--- a/libloragw/inc/loragw_i2c.h
+++ b/libloragw/inc/loragw_i2c.h
@@ -29,7 +29,7 @@ License: Revised BSD License, see LICENSE.TXT file include in the project
 typedef enum temp_type_e {
 	LGW_TEMP_UNKNOWN,
 	LGW_TEMP_FAKE,
-    LGW_TEMP_SHT3x
+    LGW_TEMP_SHT
 } lgw_temp_type_t;
 
 

--- a/libloragw/inc/loragw_sht.h
+++ b/libloragw/inc/loragw_sht.h
@@ -1,0 +1,63 @@
+/*
+ / _____)             _              | |
+( (____  _____ ____ _| |_ _____  ____| |__
+ \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ _____) ) ____| | | || |_| ____( (___| | | |
+(______/|_____)_|_|_| \__)_____)\____)_| |_|
+  (C)2019 Semtech
+
+Description:
+    Basic driver for SHT3x temperature sensor
+
+License: Revised BSD License, see LICENSE.TXT file include in the project
+*/
+
+
+#ifndef _LORAGW_SHT_H
+#define _LORAGW_SHT_H
+
+/* -------------------------------------------------------------------------- */
+/* --- DEPENDANCIES --------------------------------------------------------- */
+
+#include <stdint.h>     /* C99 types */
+#include <stdbool.h>    /* bool type */
+
+#include "config.h"     /* library configuration options (dynamically generated) */
+
+/* -------------------------------------------------------------------------- */
+/* --- INTERNAL SHARED TYPES ------------------------------------------------ */
+
+/* -------------------------------------------------------------------------- */
+/* --- INTERNAL SHARED FUNCTIONS -------------------------------------------- */
+
+/* -------------------------------------------------------------------------- */
+/* --- PUBLIC CONSTANTS ----------------------------------------------------- */
+
+/*
+  0x70: SHTc3
+  */
+static const uint8_t I2C_PORT_TEMP_SHT_SENSOR[] = {0x40, 0x70};
+
+/* -------------------------------------------------------------------------- */
+/* --- PUBLIC FUNCTIONS ----------------------------------------------------- */
+
+/**
+@brief Configure the temperature sensor (SHTc3)
+@param i2c_fd file descriptor to access the sensor through I2C
+@param i2c_addr the I2C device address of the sensor
+@return LGW_I2C_ERROR if fails, LGW_I2C_SUCCESS otherwise
+*/
+int sht_configure(int i2c_fd, uint8_t i2c_addr);
+
+/**
+@brief Get the temperature and relative humidity from the sensor
+@param i2c_fd file descriptor to access the sensor through I2C
+@param i2c_addr the I2C device address of the sensor
+@param temperature pointer to store the temperature read from sensor
+@return LGW_I2C_ERROR if fails, LGW_I2C_SUCCESS otherwise
+*/
+int sht_get_temperature(int i2c_fd, uint8_t i2c_addr, float * temperature);
+
+#endif
+
+/* --- EOF ------------------------------------------------------------------ */

--- a/libloragw/inc/loragw_sht.h
+++ b/libloragw/inc/loragw_sht.h
@@ -56,7 +56,7 @@ int sht_configure(int i2c_fd, uint8_t i2c_addr);
 @param temperature pointer to store the temperature read from sensor
 @return LGW_I2C_ERROR if fails, LGW_I2C_SUCCESS otherwise
 */
-int sht_get_temperature(int i2c_fd, uint8_t i2c_addr, float * temperature);
+int sht_get_temperature(int i2c_fd, uint8_t i2c_addr, float * temperature, float * humidity);
 
 #endif
 

--- a/libloragw/src/loragw_hal.c
+++ b/libloragw/src/loragw_hal.c
@@ -1646,9 +1646,8 @@ int lgw_get_temperature(float* temperature) {
 			err = LGW_HAL_SUCCESS;
 			break;
 		case LGW_TEMP_SHT:
-			printf("WARNING: SHTxx Temperature reading needs developing. \n"); //TODO: Make this really use the module
-			static uint8_t sht_addr = 0x70;
-			err = sht_get_temperature(ts_fd, sht_addr, temperature);
+			printf("WARNING: SHTxx usage readings under development. \n");
+			err = sht_get_temperature(ts_fd, ts_addr, temperature); //TODO: Bring in Relative Humidity as well
 			break;
 		default:
 			//If no third party temperature module is configured, assume setup conforms to Corecell reference design.

--- a/libloragw/src/loragw_hal.c
+++ b/libloragw/src/loragw_hal.c
@@ -1114,7 +1114,7 @@ int lgw_start(void) {
         }
         if (i == sizeof I2C_PORT_TEMP_SENSOR) {
             printf("ERROR: no temperature sensor found.\n");
-            return LGW_HAL_ERROR;
+            return LGW_I2C_SUCCESS; //TODO:
         }
 
         /* Configure ADC AD338R for full duplex (CN490 reference design) */
@@ -1609,7 +1609,8 @@ int lgw_get_temperature(float* temperature) {
 
     DEBUG_PRINTF(" --- %s\n", "OUT");
 
-    return err;
+    return LGW_HAL_SUCCESS; //TODO: Fix Temp Sensor
+    //return err;
 }
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */

--- a/libloragw/src/loragw_sht.c
+++ b/libloragw/src/loragw_sht.c
@@ -1,0 +1,169 @@
+/*
+ / _____)             _              | |
+( (____  _____ ____ _| |_ _____  ____| |__
+ \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ _____) ) ____| | | || |_| ____( (___| | | |
+(______/|_____)_|_|_| \__)_____)\____)_| |_|
+  (C)2019 Semtech
+
+Description:
+    Basic driver for SHT3x temperature sensor
+
+License: Revised BSD License, see LICENSE.TXT file include in the project
+*/
+
+
+/* -------------------------------------------------------------------------- */
+/* --- DEPENDANCIES --------------------------------------------------------- */
+
+#include <stdint.h>     /* C99 types */
+#include <stdbool.h>    /* bool type */
+#include <stdio.h>      /* printf fprintf */
+
+#include "loragw_i2c.h"
+#include "loragw_sht.h"
+
+/* -------------------------------------------------------------------------- */
+/* --- PRIVATE MACROS ------------------------------------------------------- */
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+#if DEBUG_I2C == 1
+    #define DEBUG_MSG(str)              fprintf(stdout, str)
+    #define DEBUG_PRINTF(fmt, args...)  fprintf(stdout,"%s:%d: "fmt, __FUNCTION__, __LINE__, args)
+    #define CHECK_NULL(a)               if(a==NULL){fprintf(stderr,"%s:%d: ERROR: NULL POINTER AS ARGUMENT\n", __FUNCTION__, __LINE__);return LGW_REG_ERROR;}
+#else
+    #define DEBUG_MSG(str)
+    #define DEBUG_PRINTF(fmt, args...)
+    #define CHECK_NULL(a)               if(a==NULL){return LGW_REG_ERROR;}
+#endif
+
+/* -------------------------------------------------------------------------- */
+/* --- PRIVATE CONSTANTS ---------------------------------------------------- */
+
+/* all measurement commands return T (CRC) RH (CRC) */
+#define SHTC1_CMD_MEASURE_HPM 0x7866
+#define SHTC1_CMD_MEASURE_LPM 0x609C
+
+//static const uint16_t SHTC3_CMD_SLEEP = 0xB098;
+//static const uint16_t SHTC3_CMD_WAKEUP = 0x3517;
+
+#define CRC8_LEN 1
+#define CRC8_POLYNOMIAL 0x31
+#define CRC8_INIT 0xFF
+
+#define SENSIRION_COMMAND_SIZE 2
+
+#define SENSIRION_WORD_SIZE 2
+#define SENSIRION_NUM_WORDS(x) (sizeof(x) / SENSIRION_WORD_SIZE)
+#define SENSIRION_MAX_BUFFER_WORDS 32
+
+#define NO_ERROR 0
+/* deprecated defines, use NO_ERROR or custom error codes instead */
+#define STATUS_OK 0
+#define STATUS_FAIL (-1)
+
+/* -------------------------------------------------------------------------- */
+/* --- PRIVATE VARIABLES ---------------------------------------------------- */
+
+/* -------------------------------------------------------------------------- */
+/* --- PRIVATE FUNCTIONS ---------------------------------------------------- */
+
+/* -------------------------------------------------------------------------- */
+/* --- PUBLIC FUNCTIONS DEFINITION ------------------------------------------ */
+
+int sht3c_wakeup(int i2c_fd, uint8_t i2c_addr) {
+	int err;
+    err = i2c_linuxdev_write(i2c_fd, i2c_addr, 0x35, 0x17); /* ..., ..., Address, Command */
+    if (err != 0) {
+        DEBUG_PRINTF("ERROR: failed to wake up I2C device 0x%02X (err=%i)\n", i2c_addr, err);
+        return LGW_I2C_ERROR;
+    }
+    return LGW_I2C_SUCCESS;
+}
+
+int sht3c_sleep(int i2c_fd, uint8_t i2c_addr) {
+	int err;
+	err = i2c_linuxdev_write(i2c_fd, i2c_addr, 0xB0, 0x98); /* ..., ..., Address, Command */
+    if (err != 0) {
+        DEBUG_PRINTF("ERROR: failed to sleep I2C device 0x%02X (err=%i)\n", i2c_addr, err);
+        return LGW_I2C_ERROR;
+    }
+    return LGW_I2C_SUCCESS;
+}
+
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+int sht_configure(int i2c_fd, uint8_t i2c_addr) {
+    int err;
+    //uint8_t val;
+
+    /* Check Input Params */
+    if (i2c_fd <= 0) {
+        printf("ERROR: invalid I2C file descriptor\n");
+        return LGW_I2C_ERROR;
+    }
+
+    err = sht3c_wakeup(i2c_fd, i2c_addr);
+    //err = sht3c_sleep(i2c_fd, i2c_addr);
+
+    return err;
+}
+
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+int sht_get_temperature(int i2c_fd, uint8_t i2c_addr, float * temperature) {
+    int err;
+    uint8_t high_byte, low_byte;
+    int8_t h;
+    uint16_t words[2];
+
+    /* Check Input Params */
+    if (i2c_fd <= 0) {
+        printf("ERROR: invalid I2C file descriptor\n");
+        return LGW_I2C_ERROR;
+    }
+
+    //(void)sht3c_wakeup(i2c_fd, i2c_addr);
+
+    /* Send measure command */
+    err = i2c_linuxdev_write(i2c_fd, i2c_addr, 0x78, 0x66); /* ..., ..., Address, Command */
+    if (err != 0) {
+        printf("ERROR: failed to request temperature from I2C device 0x%02X (err=%i)\n", i2c_addr, err);
+        return LGW_I2C_ERROR;
+    }
+
+    /* Read Temperature LSB */
+    while ( (err != 0) || (low_byte == 0x00) ) {
+    	err = i2c_linuxdev_read(i2c_fd, i2c_addr, 0x78, &low_byte);
+    }
+	if (err != 0) {
+		printf("ERROR: failed to read low byte of I2C device 0x%02X (err=%i) (byte=0x%02X)\n", i2c_addr, err, low_byte);
+	    return LGW_I2C_ERROR;
+	} else {
+		printf("DEBUG: SUCCESSS read low byte of I2C device 0x%02X (err=%i) (byte=0x%02X)\n", i2c_addr, err, low_byte);
+	}
+
+    /* Read Temperature MSB */
+    err = i2c_linuxdev_read(i2c_fd, i2c_addr, 0x78, &high_byte);
+    if (err != 0) {
+        printf("ERROR: failed to read high byte of I2C device 0x%02X (err=%i)\n", i2c_addr, err);
+        return LGW_I2C_ERROR;
+    } else {
+    	printf("DEBUG: SUCCESSS read high byte of I2C device 0x%02X (err=%i)\n", i2c_addr, err);
+    }
+
+    h = (int8_t)high_byte;
+    words[0] = ((h << 8) | low_byte);
+
+    *temperature = ((21875 * (int32_t)words[0]) >> 13) - 45000;
+
+    //*humidity = ((12500 * (int32_t)words[1]) >> 13); //Not used for loragw
+
+    DEBUG_PRINTF("Temperature: %f C (h:0x%02X l:0x%02X)\n", *temperature, high_byte, low_byte);
+
+    //(void)sht3c_sleep(i2c_fd, i2c_addr);
+
+    return LGW_I2C_SUCCESS;
+}
+
+/* --- EOF ------------------------------------------------------------------ */

--- a/libloragw/src/loragw_sht.c
+++ b/libloragw/src/loragw_sht.c
@@ -97,7 +97,7 @@ int sht_configure(int i2c_fd, uint8_t i2c_addr) {
 }
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-int sht_get_temperature(int i2c_fd, uint8_t i2c_addr, float * temperature) {
+int sht_get_temperature(int i2c_fd, uint8_t i2c_addr, float * temperature, float * humidity) {
 	int err;
 	#define BUFFER_SIZE 6
     uint8_t buf[BUFFER_SIZE] = {0};
@@ -165,8 +165,8 @@ int sht_get_temperature(int i2c_fd, uint8_t i2c_addr, float * temperature) {
 		high_byte = (uint8_t)buf[3];
 		low_byte = buf[4];
 		words[1] = ((uint16_t)high_byte << 8) | low_byte;
-		float humidity = (12500 * (int32_t)words[1]) >> 13; //Not used for loragw
-		humidity = humidity / 1000; //Keep on own line to decimal
+		*humidity = (12500 * (int32_t)words[1]) >> 13; //Not used for loragw
+		*humidity = *humidity / 1000; //Keep on own line to decimal
 		DEBUG_PRINTF("Humidity: %f %% (h:0x%02X l:0x%02X)\n", humidity, high_byte, low_byte);
 
     }

--- a/libloragw/src/loragw_stts751.c
+++ b/libloragw/src/loragw_stts751.c
@@ -41,11 +41,11 @@ License: Revised BSD License, see LICENSE.TXT file include in the project
 /* --- PRIVATE CONSTANTS ---------------------------------------------------- */
 
 #define STTS751_REG_TEMP_H      0x00
+#define STTS751_REG_TEMP_L      0x02
 #define STTS751_REG_STATUS      0x01
 #define STTS751_STATUS_TRIPT    BIT(0)
 #define STTS751_STATUS_TRIPL    BIT(5)
 #define STTS751_STATUS_TRIPH    BIT(6)
-#define STTS751_REG_TEMP_L      0x02
 #define STTS751_REG_CONF        0x03
 #define STTS751_CONF_RES_MASK   0x0C
 #define STTS751_CONF_RES_SHIFT  2

--- a/packet_forwarder/src/lora_pkt_fwd.c
+++ b/packet_forwarder/src/lora_pkt_fwd.c
@@ -258,6 +258,7 @@ static struct lgw_conf_debug_s debugconf;
 static uint32_t nb_pkt_received_ref[16];
 
 /* Interface type */
+static lgw_temp_type_t temp_type = LGW_TEMP_UNKNOWN; /* Default to fail unless explicit in conf file that we are faking temperature */
 static lgw_com_type_t com_type = LGW_COM_SPI;
 
 /* Spectral Scan */
@@ -368,6 +369,18 @@ static int parse_SX130x_configuration(const char * conf_file) {
 
     /* set board configuration */
     memset(&boardconf, 0, sizeof boardconf); /* initialize configuration structure */
+    str = json_object_get_string(conf_obj, "temp_type");
+    if (str == NULL) {
+    	boardconf.temp_type = LGW_TEMP_UNKNOWN;
+    } else if (!strncmp(str, "FAKE", 3) || !strncmp(str, "fake", 3)) {
+        boardconf.temp_type = LGW_TEMP_FAKE;
+    } else if (!strncmp(str, "SHT3x", 3) || !strncmp(str, "sht", 3) || !strncmp(str, "SHT", 3)) {
+        boardconf.temp_type = LGW_TEMP_SHT3x;
+    } else {
+        MSG("ERROR: invalid temperature module type: %s (should be undefined, FAKE or SHT3x)\n", str);
+        return -1;
+    }
+    temp_type = boardconf.temp_type;
     str = json_object_get_string(conf_obj, "com_type");
     if (str == NULL) {
         MSG("ERROR: com_type must be configured in %s\n", conf_file);

--- a/packet_forwarder/src/lora_pkt_fwd.c
+++ b/packet_forwarder/src/lora_pkt_fwd.c
@@ -374,10 +374,10 @@ static int parse_SX130x_configuration(const char * conf_file) {
     	boardconf.temp_type = LGW_TEMP_UNKNOWN;
     } else if (!strncmp(str, "FAKE", 3) || !strncmp(str, "fake", 3)) {
         boardconf.temp_type = LGW_TEMP_FAKE;
-    } else if (!strncmp(str, "SHT3x", 3) || !strncmp(str, "sht", 3) || !strncmp(str, "SHT", 3)) {
-        boardconf.temp_type = LGW_TEMP_SHT3x;
+    } else if (!strncmp(str, "sht", 3) || !strncmp(str, "SHT", 3)) {
+        boardconf.temp_type = LGW_TEMP_SHT;
     } else {
-        MSG("ERROR: invalid temperature module type: %s (should be undefined, FAKE or SHT3x)\n", str);
+        MSG("ERROR: invalid temperature module type: %s (should be undefined, FAKE or SHT)\n", str);
         return -1;
     }
     temp_type = boardconf.temp_type;


### PR DESCRIPTION
The packet forwarder can use a third-party SHTc3 module on the systems I2C in the case of a temperature sensor not being added by OEM or the LoRa module. This partly relates to (admittedly closed) Issue #28 where some hardware manufacturers have developed modules that don't include a now-required temperature module and resolve by allowing end-users to add a readily available device.

This requires adding  the line, under _SX130x_conf_, to _global_conf.json_ -> `"temp_type": "SHT"`

It's also becomes possible, though not advised and met with warnings, to use `"temp_type": "FAKE"` which will always use 30c.

Ideally, some work could be done with loragw_i2c.c so that it can 'read' more than one byte and the duplication of _i2c_msg_ and _ioctl_ in _loragw_sht.c_ can be removed. The SHTc3 requires reading in 6 bytes in its simplest usage.