### PR TITLE
Keep compatibility with USB-SPI bridge firmware prior to 1.0.0

### DIFF
--- a/libloragw/inc/loragw_mcu.h
+++ b/libloragw/inc/loragw_mcu.h
@@ -190,6 +190,11 @@ int mcu_spi_store(uint8_t * in_out_buf, size_t buf_size);
 */
 int mcu_spi_flush(int fd);
 
+/**
+ *
+*/
+void mcu_save_version(char * version);
+
 #endif
 
 /* --- EOF ------------------------------------------------------------------ */

--- a/libloragw/src/loragw_usb.c
+++ b/libloragw/src/loragw_usb.c
@@ -195,6 +195,7 @@ int lgw_usb_open(const char * com_path, void **com_target_ptr) {
             printf("ERROR: failed to ping the concentrator MCU\n");
             return LGW_USB_ERROR;
         }
+        mcu_save_version(gw_info.version + 1);
         if (strncmp(gw_info.version + 1, mcu_version_string, sizeof mcu_version_string) != 0) {
             printf("WARNING: MCU version mismatch (expected:%s, got:%s)\n", mcu_version_string, gw_info.version);
         }


### PR DESCRIPTION
This PR tries to add backwards compatiblity with old concentrators using USB-SPI bridge firmware previous to 1.0.0 (for instance RAK2287 USB).
Tested working with basicstation code. 