### PR TITLE
Enable use of additional CFLAGS

### DIFF
--- a/libloragw/Makefile
+++ b/libloragw/Makefile
@@ -11,7 +11,7 @@ CROSS_COMPILE ?=
 CC := $(CROSS_COMPILE)gcc
 AR := $(CROSS_COMPILE)ar
 
-CFLAGS := -O2 -Wall -Wextra -std=c99 -Iinc -I. -I../libtools/inc
+CFLAGS += -O2 -Wall -Wextra -std=c99 -Iinc -I. -I../libtools/inc
 
 OBJDIR = obj
 INCLUDES = $(wildcard inc/*.h) $(wildcard ../libtools/inc/*.h)

--- a/libtools/Makefile
+++ b/libtools/Makefile
@@ -7,7 +7,7 @@ CROSS_COMPILE ?=
 CC := $(CROSS_COMPILE)gcc
 AR := $(CROSS_COMPILE)ar
 
-CFLAGS := -O2 -Wall -Wextra -std=c99 -Iinc -I.
+CFLAGS += -O2 -Wall -Wextra -std=c99 -Iinc -I.
 
 OBJDIR = obj
 INCLUDES = $(wildcard inc/*.h)


### PR DESCRIPTION
Enable use of TARGET_CFLAGS in addition to specified CFLAGS, e.g. when
cross-compiling for OpenWRT

Signed-off-by: Marcus Schref <mschref@web.de>