### PR TITLE
Fixed code according to deprecated SysFS and new SysFS available in debian bookworm

### DIFF
--- a/libloragw/src/loragw_gps.c
+++ b/libloragw/src/loragw_gps.c
@@ -535,7 +535,7 @@ enum gps_msg lgw_parse_nmea(const char *serial_buff, int buff_size) {
         memcpy(parser_buf, serial_buff, buff_size);
         parser_buf[buff_size] = '\0';
         nb_fields = str_chop(parser_buf, buff_size, ',', str_index, ARRAY_SIZE(str_index));
-        if (nb_fields != 13) {
+        if (nb_fields < 13 || nb_fields > 14) {
             DEBUG_MSG("Warning: invalid RMC sentence (number of fields)\n");
             return IGNORED;
         }

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,16 @@
+This is a repo forked from
+https://github.com/Lora-net/sx1302_hal
+
+But there is another cloned repo:
+https://www.statuscode200.com/gitlab/lorawan-setup/sx1302_hal.git
+with modifications to make it work with recent Bookworm based raspberry pi
+OS and accepts GPS from recievers other than u-blox.
+
+I copied the modifications from the other cloned repo into this repo,
+to make the modifications visible for people who find the original repo
+and to make pull request to the original repo.
+
+
 	 / _____)             _              | |
 	( (____  _____ ____ _| |_ _____  ____| |__
 	 \____ \| ___ |    (_   _) ___ |/ ___)  _ \

--- a/tools/reset_lgw.sh
+++ b/tools/reset_lgw.sh
@@ -12,9 +12,9 @@
 # GPIO mapping has to be adapted with HW
 #
 
-SX1302_RESET_PIN=23     # SX1302 reset
+SX1302_RESET_PIN=17     # SX1302 reset
 SX1302_POWER_EN_PIN=18  # SX1302 power enable
-SX1261_RESET_PIN=22     # SX1261 reset (LBT / Spectral Scan)
+SX1261_RESET_PIN=5     # SX1261 reset (LBT / Spectral Scan)
 AD5338R_RESET_PIN=13    # AD5338R reset (full-duplex CN490 reference design)
 
 WAIT_GPIO() {
@@ -22,17 +22,13 @@ WAIT_GPIO() {
 }
 
 init() {
-    # setup GPIOs
-    echo "$SX1302_RESET_PIN" > /sys/class/gpio/export; WAIT_GPIO
-    echo "$SX1261_RESET_PIN" > /sys/class/gpio/export; WAIT_GPIO
-    echo "$SX1302_POWER_EN_PIN" > /sys/class/gpio/export; WAIT_GPIO
-    echo "$AD5338R_RESET_PIN" > /sys/class/gpio/export; WAIT_GPIO
 
     # set GPIOs as output
-    echo "out" > /sys/class/gpio/gpio$SX1302_RESET_PIN/direction; WAIT_GPIO
-    echo "out" > /sys/class/gpio/gpio$SX1261_RESET_PIN/direction; WAIT_GPIO
-    echo "out" > /sys/class/gpio/gpio$SX1302_POWER_EN_PIN/direction; WAIT_GPIO
-    echo "out" > /sys/class/gpio/gpio$AD5338R_RESET_PIN/direction; WAIT_GPIO
+    pinctrl set $SX1302_RESET_PIN op; WAIT_GPIO
+    pinctrl set $SX1261_RESET_PIN op; WAIT_GPIO
+    pinctrl set $SX1302_POWER_EN_PIN op; WAIT_GPIO
+    pinctrl set $AD5338R_RESET_PIN op; WAIT_GPIO
+
 }
 
 reset() {
@@ -42,16 +38,20 @@ reset() {
     echo "CoreCell ADC reset through GPIO$AD5338R_RESET_PIN..."
 
     # write output for SX1302 CoreCell power_enable and reset
-    echo "1" > /sys/class/gpio/gpio$SX1302_POWER_EN_PIN/value; WAIT_GPIO
+    pinctrl set $SX1302_POWER_EN_PIN op; WAIT_GPIO
+    pinctrl set $SX1302_POWER_EN_PIN op dh; WAIT_GPIO
 
-    echo "1" > /sys/class/gpio/gpio$SX1302_RESET_PIN/value; WAIT_GPIO
-    echo "0" > /sys/class/gpio/gpio$SX1302_RESET_PIN/value; WAIT_GPIO
+    pinctrl set $SX1302_RESET_PIN op; WAIT_GPIO
+    pinctrl set $SX1302_RESET_PIN op dh; WAIT_GPIO
+    pinctrl set $SX1302_RESET_PIN op dl; WAIT_GPIO
 
-    echo "0" > /sys/class/gpio/gpio$SX1261_RESET_PIN/value; WAIT_GPIO
-    echo "1" > /sys/class/gpio/gpio$SX1261_RESET_PIN/value; WAIT_GPIO
+    pinctrl set $SX1261_RESET_PIN op; WAIT_GPIO
+    pinctrl set $SX1261_RESET_PIN op dl; WAIT_GPIO
+    pinctrl set $SX1261_RESET_PIN op dh; WAIT_GPIO
 
-    echo "0" > /sys/class/gpio/gpio$AD5338R_RESET_PIN/value; WAIT_GPIO
-    echo "1" > /sys/class/gpio/gpio$AD5338R_RESET_PIN/value; WAIT_GPIO
+    pinctrl set $AD5338R_RESET_PIN op; WAIT_GPIO
+    pinctrl set $AD5338R_RESET_PIN op dl; WAIT_GPIO
+    pinctrl set $AD5338R_RESET_PIN op dh; WAIT_GPIO
 }
 
 term() {


### PR DESCRIPTION
The old code is based on an old SysFS that allowes ts set GPIOs by writing "echo 1" or "echo 0" to a file - but these files don't exists anymore. Now it's necessary to use the cmd 'pinctrl'.
Another fix is related to GPS data - not just check for a lenght of 13 bytes - check for 14 bytes as well.