### PR TITLE
test_loragw_com: do not elect a 0-size random buffer

### DIFF
--- a/libloragw/tst/test_loragw_com.c
+++ b/libloragw/tst/test_loragw_com.c
@@ -188,7 +188,7 @@ int main(int argc, char ** argv)
          *
          * ***********************************************/
 
-        size = rand() % max_buff_size;
+        size = (rand() % (max_buff_size - 1)) + 1;
         for (i = 0; i < size; ++i) {
             test_buff[i] = rand() & 0xFF;
         }


### PR DESCRIPTION
Inner calls rejects the request when random buffer size is zero.
Generate random buffers of 1-byte minimum.