### PR TITLE
Refactor GPIO setup and reset commands for bookworn and newer debian distro

### DIFF
--- a/tools/reset_lgw.sh
+++ b/tools/reset_lgw.sh
@@ -22,17 +22,21 @@ WAIT_GPIO() {
 }
 
 init() {
-    # setup GPIOs
-    echo "$SX1302_RESET_PIN" > /sys/class/gpio/export; WAIT_GPIO
-    echo "$SX1261_RESET_PIN" > /sys/class/gpio/export; WAIT_GPIO
-    echo "$SX1302_POWER_EN_PIN" > /sys/class/gpio/export; WAIT_GPIO
-    echo "$AD5338R_RESET_PIN" > /sys/class/gpio/export; WAIT_GPIO
+    # # setup GPIOs
+    pinctrl set $SX1302_RESET_PIN op; WAIT_GPIO
+    pinctrl set $SX1261_RESET_PIN op; WAIT_GPIO
+    pinctrl set $SX1302_POWER_EN_PIN op; WAIT_GPIO
+    pinctrl set $AD5338R_RESET_PIN op; WAIT_GPIO
+    # echo "$SX1302_RESET_PIN" > /sys/class/gpio/export; WAIT_GPIO
+    # echo "$SX1261_RESET_PIN" > /sys/class/gpio/export; WAIT_GPIO
+    # echo "$SX1302_POWER_EN_PIN" > /sys/class/gpio/export; WAIT_GPIO
+    # echo "$AD5338R_RESET_PIN" > /sys/class/gpio/export; WAIT_GPIO
 
-    # set GPIOs as output
-    echo "out" > /sys/class/gpio/gpio$SX1302_RESET_PIN/direction; WAIT_GPIO
-    echo "out" > /sys/class/gpio/gpio$SX1261_RESET_PIN/direction; WAIT_GPIO
-    echo "out" > /sys/class/gpio/gpio$SX1302_POWER_EN_PIN/direction; WAIT_GPIO
-    echo "out" > /sys/class/gpio/gpio$AD5338R_RESET_PIN/direction; WAIT_GPIO
+    # # set GPIOs as output
+    # echo "out" > /sys/class/gpio/gpio$SX1302_RESET_PIN/direction; WAIT_GPIO
+    # echo "out" > /sys/class/gpio/gpio$SX1261_RESET_PIN/direction; WAIT_GPIO
+    # echo "out" > /sys/class/gpio/gpio$SX1302_POWER_EN_PIN/direction; WAIT_GPIO
+    # echo "out" > /sys/class/gpio/gpio$AD5338R_RESET_PIN/direction; WAIT_GPIO
 }
 
 reset() {
@@ -42,36 +46,49 @@ reset() {
     echo "CoreCell ADC reset through GPIO$AD5338R_RESET_PIN..."
 
     # write output for SX1302 CoreCell power_enable and reset
-    echo "1" > /sys/class/gpio/gpio$SX1302_POWER_EN_PIN/value; WAIT_GPIO
+    # echo "1" > /sys/class/gpio/gpio$SX1302_POWER_EN_PIN/value; WAIT_GPIO
+    pinctrl set $SX1302_POWER_EN_PIN dh; WAIT_GPIO
 
-    echo "1" > /sys/class/gpio/gpio$SX1302_RESET_PIN/value; WAIT_GPIO
-    echo "0" > /sys/class/gpio/gpio$SX1302_RESET_PIN/value; WAIT_GPIO
+    # echo "1" > /sys/class/gpio/gpio$SX1302_RESET_PIN/value; WAIT_GPIO
+    # echo "0" > /sys/class/gpio/gpio$SX1302_RESET_PIN/value; WAIT_GPIO
+    pinctrl set $SX1302_RESET_PIN dh; WAIT_GPIO
+    pinctrl set $SX1302_RESET_PIN dl; WAIT_GPIO
 
-    echo "0" > /sys/class/gpio/gpio$SX1261_RESET_PIN/value; WAIT_GPIO
-    echo "1" > /sys/class/gpio/gpio$SX1261_RESET_PIN/value; WAIT_GPIO
+    # echo "0" > /sys/class/gpio/gpio$SX1261_RESET_PIN/value; WAIT_GPIO
+    # echo "1" > /sys/class/gpio/gpio$SX1261_RESET_PIN/value; WAIT_GPIO
+    pinctrl set $SX1261_RESET_PIN dh; WAIT_GPIO
+    pinctrl set $SX1261_RESET_PIN dl; WAIT_GPIO
 
-    echo "0" > /sys/class/gpio/gpio$AD5338R_RESET_PIN/value; WAIT_GPIO
-    echo "1" > /sys/class/gpio/gpio$AD5338R_RESET_PIN/value; WAIT_GPIO
+    # echo "0" > /sys/class/gpio/gpio$AD5338R_RESET_PIN/value; WAIT_GPIO
+    # echo "1" > /sys/class/gpio/gpio$AD5338R_RESET_PIN/value; WAIT_GPIO
+    pinctrl set $AD5338R_RESET_PIN dh; WAIT_GPIO
+    pinctrl set $AD5338R_RESET_PIN dl; WAIT_GPIO
 }
 
 term() {
-    # cleanup all GPIOs
-    if [ -d /sys/class/gpio/gpio$SX1302_RESET_PIN ]
-    then
-        echo "$SX1302_RESET_PIN" > /sys/class/gpio/unexport; WAIT_GPIO
-    fi
-    if [ -d /sys/class/gpio/gpio$SX1261_RESET_PIN ]
-    then
-        echo "$SX1261_RESET_PIN" > /sys/class/gpio/unexport; WAIT_GPIO
-    fi
-    if [ -d /sys/class/gpio/gpio$SX1302_POWER_EN_PIN ]
-    then
-        echo "$SX1302_POWER_EN_PIN" > /sys/class/gpio/unexport; WAIT_GPIO
-    fi
-    if [ -d /sys/class/gpio/gpio$AD5338R_RESET_PIN ]
-    then
-        echo "$AD5338R_RESET_PIN" > /sys/class/gpio/unexport; WAIT_GPIO
-    fi
+    echo "Resetting Pins..."
+    pinctrl set $SX1302_RESET_PIN no; WAIT_GPIO
+    pinctrl set $SX1261_RESET_PIN no; WAIT_GPIO
+    pinctrl set $SX1302_POWER_EN_PIN no; WAIT_GPIO
+    pinctrl set $AD5338R_RESET_PIN no; WAIT_GPIO
+    echo "Resetting Done..."
+    # # cleanup all GPIOs
+    # if [ -d /sys/class/gpio/gpio$SX1302_RESET_PIN ]
+    # then
+    #     echo "$SX1302_RESET_PIN" > /sys/class/gpio/unexport; WAIT_GPIO
+    # fi
+    # if [ -d /sys/class/gpio/gpio$SX1261_RESET_PIN ]
+    # then
+    #     echo "$SX1261_RESET_PIN" > /sys/class/gpio/unexport; WAIT_GPIO
+    # fi
+    # if [ -d /sys/class/gpio/gpio$SX1302_POWER_EN_PIN ]
+    # then
+    #     echo "$SX1302_POWER_EN_PIN" > /sys/class/gpio/unexport; WAIT_GPIO
+    # fi
+    # if [ -d /sys/class/gpio/gpio$AD5338R_RESET_PIN ]
+    # then
+    #     echo "$AD5338R_RESET_PIN" > /sys/class/gpio/unexport; WAIT_GPIO
+    # fi
 }
 
 case "$1" in


### PR DESCRIPTION
Replaced GPIO commands with pinctrl commands for better control over GPIO pins. modifyed for newer kernal of Raspberry pi 4b bookworm and newer